### PR TITLE
Fix rendering of HTML option

### DIFF
--- a/content/idiomatic-rust/table.js
+++ b/content/idiomatic-rust/table.js
@@ -60,7 +60,9 @@ $(document).ready(function () {
             .sort()
             .unique()
             .each(function (d, j) {
-              select.add(new Option(d));
+              let option = new Option("");
+              option.innerHTML(d);
+              select.add(option);
             });
         });
     },


### PR DESCRIPTION
The difficulty column contains HTML.
The value should not be escaped.
Fixes mre/idiomatic-rust#45