### PR TITLE
Use s-size player in Thunderbird Episode

### DIFF
--- a/content/podcast/s02e03-thunderbird/index.md
+++ b/content/podcast/s02e03-thunderbird/index.md
@@ -11,7 +11,7 @@ episode = "03"
 series = "Podcast"
 +++
 
-<div><script id="letscast-player-d02c0302" src="https://letscast.fm/podcasts/rust-in-production-82281512/episodes/rust-in-production-ep-10-thunderbird-s-brendan-abolivier/player.js?size=m-alternative"></script></div>
+<div><script id="letscast-player-d02c0302" src="https://letscast.fm/podcasts/rust-in-production-82281512/episodes/rust-in-production-ep-10-thunderbird-s-brendan-abolivier/player.js?size=s"></script></div>
 
 There are probably only a handful of open-source projects that had a bigger
 impact on the world than Mozilla Thunderbird. The email client has been around


### PR DESCRIPTION
We use the "s" size of the Let's Cast player in all other episodes.