### PR TITLE
Make wording of `uv` less mysterious

### DIFF
--- a/content/podcast/s04e03-astral/index.md
+++ b/content/podcast/s04e03-astral/index.md
@@ -16,11 +16,12 @@ series = "Podcast"
 
 Up until a few years ago, Python tooling was a nightmare:
 basic tasks like installing packages or managing Python versions was a pain.
-The tools were brittle and did not work well together.
+The tools were brittle and did not work well together,
+mired in a swamp of underspecified implementation defined behaviour.
 
-Then, suddenly, we saw a renaissance of new ideas in the Python ecosystem.
-It started with [Poetry](https://python-poetry.org/) and [pipx](https://pypa.github.io/pipx/) and
-continued with tooling written in Rust like [rye](https://rye.astral.sh/), which later got incorporated into 
+Then, apparently suddenly, but in reality backed by years of ongoing work on formal interoperability specifications,
+we saw a renaissance of new ideas in the Python ecosystem.
+It started with [Poetry](https://python-poetry.org/) and [pipx](https://pypa.github.io/pipx/) and continued with tooling written in Rust like [rye](https://rye.astral.sh/), which later got incorporated into 
 [Astral](https://astral.sh/).
 
 Astral in particular contributed a very important piece to the puzzle: `uv`

--- a/content/podcast/s04e03-astral/index.md
+++ b/content/podcast/s04e03-astral/index.md
@@ -21,7 +21,8 @@ mired in a swamp of underspecified implementation defined behaviour.
 
 Then, apparently suddenly, but in reality backed by years of ongoing work on formal interoperability specifications,
 we saw a renaissance of new ideas in the Python ecosystem.
-It started with [Poetry](https://python-poetry.org/) and [pipx](https://pypa.github.io/pipx/) and continued with tooling written in Rust like [rye](https://rye.astral.sh/), which later got incorporated into 
+It started with [Poetry](https://python-poetry.org/) and [pipx](https://pypa.github.io/pipx/) and
+continued with tooling written in Rust like [rye](https://rye.astral.sh/), which later got incorporated into 
 [Astral](https://astral.sh/).
 
 Astral in particular contributed a very important piece to the puzzle: `uv`


### PR DESCRIPTION
I saw this shared on reddit and noted that the standards work that made all this possible was mentioned with no word.

I wasn’t sure about the timeline and asked in the PyPA discord, where Alyssa Coghlan contributed this version and allowed me to share it.
She commented

> It didn't really start directly with poetry and pipenv either, it started with PEP 440 (standardised version numbers) and PEP 508 (standardised dependency specifiers). Those were what decoupled transitive dependency resolution from the idiosyncrasies of `easy_install` and the pre-standardisation `pip` resolver (and eventually PEP 517 was able to knock out the reliance on `./setup.py install` as the expected build backend interface).