### PR TITLE
Fix services page video embed

### DIFF
--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -6,7 +6,10 @@ description = "Friendly, professional Rust consulting services to help companies
 aliases = ["about"]
 +++
 
-<script src="https://fast.wistia.com/embed/medias/crzddicf9e.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_crzddicf9e seo=false videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/crzddicf9e/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
+<video controls style="width: 100%; max-width: 800px; height: auto; margin: 0 auto; display: block;">
+  <source src="https://github.com/corrode/corrode.github.io/releases/download/assets/corrode.mp4" type="video/mp4">
+  Your browser does not support the video tag.
+</video>
 
 ## Here’s the problem...
 


### PR DESCRIPTION
Replace broken Wistia video embed with GitHub-hosted video. The video is now served from GitHub releases for better reliability.