### PR TITLE
Restructure footer: Offerings + tidy Company column

### DIFF
--- a/templates/snippets/footer.html
+++ b/templates/snippets/footer.html
@@ -61,12 +61,10 @@
     </div>
     <div class="footer-container">
         <div class="footer-column">
-            <h3>Company</h3>
+            <h3>Offerings</h3>
             <ul class="footer-links">
-                <li><a href="/services/">Consulting</a></li>
-                <li><a href="/mentorship/">Mentorship</a></li>
-                <li><a href="/blog/why-rust/">Why Rust?</a></li>
-                <li><a href="/quote/">Business Inquiries</a></li>
+                <li><a href="/services/">For Teams</a></li>
+                <li><a href="/mentorship/">For Individuals</a></li>
             </ul>
         </div>
 
@@ -76,6 +74,7 @@
                 <li><a href="/blog/">Blog</a></li>
                 <li><a href="/podcast">Podcast</a></li>
                 <li><a href="/workshops/">Workshops</a></li>
+                <li><a href="/blog/why-rust/">Why Rust?</a></li>
                 <li><a href="/learn/case-studies/">Case Studies</a></li>
                 <li><a href="/blog/rust-conferences-2025/">Conferences</a></li>
                 <li>
@@ -129,7 +128,7 @@
         </div>
 
         <div class="footer-column">
-            <h3>Connect</h3>
+            <h3>Company</h3>
             <ul class="footer-links">
                 <li><a href="https://github.com/corrode">GitHub</a></li>
                 <li>


### PR DESCRIPTION
## Summary

Tidies up the footer's first and last columns.

### Changes
- **"Company" column → "Offerings"**, reduced to two clear audience links:
  - **For Teams** -> `/services`
  - **For Individuals** -> `/mentorship`
- **Removed "Business Inquiries"** (`/quote/`) - outdated.
- **Moved "Why Rust?"** into the **Resources** column (it's a blog article, not an offering, so it didn't belong under Offerings).
- **"Connect" column → "Company"** (GitHub, LinkedIn, Legal Notice).

### Before / after

| Column 1 | -> | Column 1 |
| --- | --- | --- |
| **Company**: Consulting, Mentorship, Why Rust?, Business Inquiries | | **Offerings**: For Teams, For Individuals |

| Last column | -> | Last column |
| --- | --- | --- |
| **Connect**: GitHub, LinkedIn, Legal Notice | | **Company**: GitHub, LinkedIn, Legal Notice |

## Validation
- `zola build` -> 89 pages, 0 orphan.
- Verified footer renders: `Offerings · Resources · Tools · Migration Guides · Company`; no `/quote/` link remains.
