### PR TITLE
Adjust CTA nav styling

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -339,13 +339,13 @@ nav {
         }
 
         .cta-button {
-            background-color: white;
+            background-color: $brightBgrd;
             color: $brightPrim;
-            border-color: white;
+            border-color: $brightBgrd;
 
             &:hover {
-                background-color: $brightBgrd;
-                border-color: $brightBgrd;
+                background-color: $brightBgrdScnd;
+                border-color: $brightBgrdScnd;
                 color: $brightPrim;
             }
 

--- a/sass/_mentorship.scss
+++ b/sass/_mentorship.scss
@@ -40,20 +40,19 @@
         display: none;
     }
 
-    // The page background is always $brightPrim, so the default button (dark on
-    // dark) would be invisible. Always use the light-on-dark treatment here.
+    // The page background is always $brightPrim, so keep the CTA on the orange treatment.
     .cta-button {
-        background-color: white;
+        background-color: $brightBgrd;
         color: $brightPrim;
-        border-color: white;
+        border-color: $brightBgrd;
 
         span {
             color: $brightPrim;
         }
 
         &:hover {
-            background-color: $brightBgrd;
-            border-color: $brightBgrd;
+            background-color: $brightBgrdScnd;
+            border-color: $brightBgrdScnd;
             color: $brightPrim;
 
             span {

--- a/templates/snippets/nav.html
+++ b/templates/snippets/nav.html
@@ -67,7 +67,7 @@
         </li>
         <li>
             <a href="{{ config.base_url ~ '/services' }}" class="cta-button">
-                <span>Consulting</span>
+                <span>Consulting&nbsp;→</span>
             </a>
         </li>
     </ul>


### PR DESCRIPTION
Updates the nav CTA label and button colors, including the mentorship page override, so the CTA uses the orange treatment consistently.